### PR TITLE
Raspberry Pi 5 - Code tested on Raspbian with multiple USB Audio Cards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ I recommend using Homebrew for all installations.
 
 ## Setup for Raspberry Pi 
 
-This setup uses a USB Audio Input 
+This setup uses a USB Audio Input from Alsa Record on the Pi 5 
 
-`arecord -D hw:2,0 -c 1 -r 44100 -f S16_LE | ./feed_my_wled.py`
+`arecord -D hw:2,0 -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py`
+`arecord -D default:CARD=Device -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py -c feed_my_wled-ch1.conf`
+`arecord -D default:CARD=Device_1 -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py -c feed_my_wled-ch2.conf`
+`arecord -D default:CARD=Device_2 -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py -c feed_my_wled-ch3.conf`
 
 
 ### About Me

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ This setup uses a USB Audio Input from Alsa Record on the Pi 5
 `arecord -D default:CARD=Device_1 -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py -c feed_my_wled-ch2.conf`
 `arecord -D default:CARD=Device_2 -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py -c feed_my_wled-ch3.conf`
 
+## Linux Requirements:
+`sudo apt install libasound2-dev`
+and
+`sudo apt install python3-alsaaudio`
+or
+`pip install pyalsaaudio`
 
 ### About Me
 This is my first project on GitHub and also my first "real" project written in Python, a language I’ve never used before. So, if you see something weird or unusual, please have mercy and let me know how I can improve. Regards, Chris

--- a/README.md
+++ b/README.md
@@ -76,5 +76,12 @@ I recommend using Homebrew for all installations.
 # `pactl load-module module-pipe-sink sink_name=wled file=/tmp/wled format=s16le rate=44100 channels=1`
 # `cat /tmp/wled | ./feed_my_wled.py`
 
+## Setup for Raspberry Pi 
+
+This setup uses a USB Audio Input 
+
+`arecord -D hw:2,0 -c 1 -r 44100 -f S16_LE | ./feed_my_wled.py`
+
+
 ### About Me
 This is my first project on GitHub and also my first "real" project written in Python, a language I’ve never used before. So, if you see something weird or unusual, please have mercy and let me know how I can improve. Regards, Chris

--- a/feed_my_wled-ch1.conf
+++ b/feed_my_wled-ch1.conf
@@ -1,0 +1,21 @@
+[WLED]
+# The IP address of the WLED device
+#WLED_IP_ADDRESS = 192.168.1.45
+# Using Multicast IP to feed all WLEDs on the same network
+WLED_IP_ADDRESS = 239.0.0.1
+
+#WLED_IPS = ["192.168.98.175", "192.168.98.155"]
+
+# The UDP port for the connection (default: 11988)
+WLED_UDP_PORT = 11988
+
+[Audio]
+# The sample rate of the audio stream (default for Shairport is 88200)
+#sample_rate = 88200
+sample_rate = 48000
+
+# Size of the buffer in bytes (increase to add more delay)
+buffer_size = 163840
+
+# Size of the data chunks in bytes (increase to reduce bandwidth usage)
+chunk_size = 8192

--- a/feed_my_wled-ch2.conf
+++ b/feed_my_wled-ch2.conf
@@ -1,0 +1,21 @@
+[WLED]
+# The IP address of the WLED device
+#WLED_IP_ADDRESS = 192.168.1.45
+# Using Multicast IP to feed all WLEDs on the same network
+WLED_IP_ADDRESS = 239.0.0.1
+
+#WLED_IPS = ["192.168.98.175", "192.168.98.155"]
+
+# The UDP port for the connection (default: 11988)
+WLED_UDP_PORT = 12988
+
+[Audio]
+# The sample rate of the audio stream (default for Shairport is 88200)
+#sample_rate = 88200
+sample_rate = 48000
+
+# Size of the buffer in bytes (increase to add more delay)
+buffer_size = 163840
+
+# Size of the data chunks in bytes (increase to reduce bandwidth usage)
+chunk_size = 8192

--- a/feed_my_wled-ch3.conf
+++ b/feed_my_wled-ch3.conf
@@ -1,0 +1,21 @@
+[WLED]
+# The IP address of the WLED device
+#WLED_IP_ADDRESS = 192.168.1.45
+# Using Multicast IP to feed all WLEDs on the same network
+WLED_IP_ADDRESS = 239.0.0.1
+
+#WLED_IPS = ["192.168.98.175", "192.168.98.155"]
+
+# The UDP port for the connection (default: 11988)
+WLED_UDP_PORT = 13988
+
+[Audio]
+# The sample rate of the audio stream (default for Shairport is 88200)
+#sample_rate = 88200
+sample_rate = 48000
+
+# Size of the buffer in bytes (increase to add more delay)
+buffer_size = 163840
+
+# Size of the data chunks in bytes (increase to reduce bandwidth usage)
+chunk_size = 8192

--- a/feed_my_wled.conf
+++ b/feed_my_wled.conf
@@ -1,6 +1,10 @@
 [WLED]
 # The IP address of the WLED device
-WLED_IP_ADDRESS = 192.168.1.45
+#WLED_IP_ADDRESS = 192.168.1.45
+# Using Multicast IP to feed all WLEDs on the same network
+WLED_IP_ADDRESS = 239.0.0.1
+
+#WLED_IPS = ["192.168.98.175", "192.168.98.155"]
 
 # The UDP port for the connection (default: 11988)
 WLED_UDP_PORT = 11988

--- a/feed_my_wled.py
+++ b/feed_my_wled.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 import sys
 import configparser
 import socket
@@ -15,9 +14,7 @@ config_parser.add_argument(
     default="feed_my_wled.conf",
     help="Configuration file"
 )
-
 config_args, remaining = config_parser.parse_known_args()
-
 
 # load preferences file
 config = configparser.ConfigParser()
@@ -32,14 +29,54 @@ sample_rate = config.getint("Audio", "sample_rate")
 buffer_size = config.getint("Audio", "buffer_size")
 chunk_size = config.getint("Audio", "chunk_size")
 
+# Second-stage parser: full CLI, including the audio source selection.
+# This reuses -c/--config_file (already consumed above) plus new options
+# that control whether audio comes from a pipe (stdin) or is captured
+# directly from a local input device (e.g. a mic or a loopback/monitor
+# device) using PyAudio.
+parser = argparse.ArgumentParser(
+    description="Feed audio-reactive UDP data to WLED.",
+    parents=[config_parser]
+)
+parser.add_argument(
+    "-s", "--source",
+    choices=["stdin", "mic"],
+    default="stdin",
+    help="Audio source: 'stdin' reads from a pipe (default, current behavior, "
+         "e.g. 'arecord ... | ./feed_my_wled.py'), 'mic' captures audio "
+         "directly from a local ALSA capture device, no external pipe needed."
+)
+parser.add_argument(
+    "-D", "--alsa-device",
+    default="default",
+    help="ALSA PCM device string to capture from when --source mic is selected. "
+         "Uses the exact same syntax as arecord's -D flag, "
+         "e.g. 'default:CARD=Device'. Defaults to 'default'."
+)
+parser.add_argument(
+    "--list-devices",
+    action="store_true",
+    help="List available ALSA capture device names (usable with -D/--alsa-device) and exit."
+)
+args = parser.parse_args(remaining)
+
+if args.list_devices:
+    import alsaaudio
+    print("Available ALSA capture devices:")
+    for name in alsaaudio.pcms(alsaaudio.PCM_CAPTURE):
+        print(f"  {name}")
+    print("\nUse one of these with: --source mic -D <name>")
+    sys.exit(0)
+
 # def vars
 previous_smoothed_level = 0.0
-ring_buffer = deque(maxlen=buffer_size // chunk_size)  # Ringpuffer für Blöcke (standardmäßig leer)
+ring_buffer = deque(maxlen=buffer_size // chunk_size) # Ringpuffer für Blöcke (standardmäßig leer)
 
 # create socket
 udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 ## functions
+
 # calculating fft
 def calculate_fft(audio_chunk, sample_rate):
     """
@@ -75,7 +112,7 @@ def calculate_fft(audio_chunk, sample_rate):
         # return calced values
         return fft_values, raw_level, peak_level, fft_magnitude_sum, fft_peak_frequency
 
-        #error handling
+    #error handling
     except Exception as e:
         print(f"Error at calcing FFT: {e}")
         return None, 0, 0, 0, 0, 0
@@ -92,29 +129,81 @@ def create_udp_packet(fft_values, raw_level, smoothed_level, peak_level, fft_mag
     :param fft_peak_frequency: dominant frequency of audiosignal
     :return: formated UDP-package
     """
-
     # Convert Values
-    peak_level = int(peak_level)  # limit to uint8
-    fft_values = [int(v) for v in fft_values]  # limit to uint8
+    peak_level = int(peak_level)               # limit to uint8
+    fft_values = [int(v) for v in fft_values]   # limit to uint8
 
     # Create package according to the WLED Protocol
-    udp_packet = struct.pack('<6s2B2fBB16B2B2f',        # don't mess with that!
-        b'00002',                   # Header (6 Bytes)
-        0,0,                        # Gap (2 Bytes)
-        float(raw_level),           # Raw Level (4 Bytes Float)
-        float(smoothed_level),      # Smoothed Level (4 Bytes Float)
-        peak_level,                 # Peak Level (1 Byte)
-        0,                          # static 0 (1 Byte)
-        *fft_values,                # FFT Result (16 Bytes)
-        0,0,                        # Gap (2 Bytes)
-        float(fft_magnitude_sum),   # FFT Magnitude (4 Bytes Float)
-        float(fft_peak_frequency))  # FFT Major Peak (4 Bytes Float)
+    udp_packet = struct.pack('<6s2B2fBB16B2B2f',  # don't mess with that!
+        b'00002',                     # Header (6 Bytes)
+        0,0,                          # Gap (2 Bytes)
+        float(raw_level),             # Raw Level (4 Bytes Float)
+        float(smoothed_level),        # Smoothed Level (4 Bytes Float)
+        peak_level,                   # Peak Level (1 Byte)
+        0,                            # static 0 (1 Byte)
+        *fft_values,                  # FFT Result (16 Bytes)
+        0,0,                          # Gap (2 Bytes)
+        float(fft_magnitude_sum),     # FFT Magnitude (4 Bytes Float)
+        float(fft_peak_frequency))    # FFT Major Peak (4 Bytes Float)
+
     return udp_packet
 
-# main function
-def stream_audio_to_wled():
+
+def make_stdin_reader():
     """
-    Reads audiodata from stream and send analyzed fft results to WLED
+    Returns a zero-arg callable that reads one chunk_size block of raw
+    audio bytes from stdin (the original piped-input behavior).
+    """
+    def _read():
+        return sys.stdin.buffer.read(chunk_size)
+    return _read
+
+
+def make_mic_reader(alsa_device):
+    """
+    Returns a zero-arg callable that reads one chunk_size block of raw
+    audio bytes directly from an ALSA capture device (same device string
+    syntax as `arecord -D ...`), replacing the external arecord pipe.
+    """
+    import alsaaudio
+
+    # chunk_size is in bytes (mono, 16-bit = 2 bytes/frame)
+    frames_per_period = max(1, chunk_size // 2)
+
+    pcm = alsaaudio.PCM(
+        type=alsaaudio.PCM_CAPTURE,
+        mode=alsaaudio.PCM_NORMAL,
+        device=alsa_device,
+        channels=1,
+        rate=sample_rate,
+        format=alsaaudio.PCM_FORMAT_S16_LE,
+        periodsize=frames_per_period,
+    )
+
+    buffer = bytearray()
+
+    def _read():
+        nonlocal buffer
+        # Accumulate until we have a full chunk_size block, since ALSA
+        # periods don't always land exactly on chunk_size boundaries.
+        while len(buffer) < chunk_size:
+            length, data = pcm.read()
+            if length > 0:
+                buffer.extend(data)
+        chunk, remainder = bytes(buffer[:chunk_size]), buffer[chunk_size:]
+        buffer = bytearray(remainder)
+        return chunk
+
+    _read.pcm = pcm
+    return _read
+
+
+# main function
+def stream_audio_to_wled(read_chunk, source_label):
+    """
+    Reads audiodata from the given source and sends analyzed fft results to WLED
+    :param read_chunk: zero-arg callable returning chunk_size bytes of raw audio
+    :param source_label: human readable description of the source, for logging
     """
     global previous_smoothed_level, ring_buffer
 
@@ -123,44 +212,58 @@ def stream_audio_to_wled():
         ring_buffer.append(b"\x00" * chunk_size)
 
     try:
-        print(f"Starting Pipe to WLED at {WLED_IP_ADDRESS}:{WLED_UDP_PORT} ")
+        print(f"Starting {source_label} to WLED at {WLED_IP_ADDRESS}:{WLED_UDP_PORT} ")
 
-        # open stream from pipe
+        # open stream from source
         while True:
-            # read datas from pipe
-            audio_data = sys.stdin.buffer.read(chunk_size)
+            # read datas from source
+            audio_data = read_chunk()
             if audio_data:
                 ring_buffer.append(audio_data)  # push data to buffer
 
-            # combine blocks for prozessing
-            combined_data = b"".join(ring_buffer)
+                # combine blocks for prozessing
+                combined_data = b"".join(ring_buffer)
 
-            # Calc FFT and Peaks with buffersize
-            fft_result = calculate_fft(combined_data[:chunk_size], sample_rate)
-            if fft_result[0] is None:
-                print("Unvalid FFT-Datas, skip actual block.")
-                continue
+                # Calc FFT and Peaks with buffersize
+                fft_result = calculate_fft(combined_data[:chunk_size], sample_rate)
+                if fft_result[0] is None:
+                    print("Unvalid FFT-Datas, skip actual block.")
+                    continue
 
-            # feed fft_result to its vars
-            fft_data, raw_level, peak_level, fft_magnitude_sum, fft_peak_frequency = fft_result
+                # feed fft_result to its vars
+                fft_data, raw_level, peak_level, fft_magnitude_sum, fft_peak_frequency = fft_result
 
-            # Smooth the Peaks (Moving Average)
-            smoothed_level = (0.8 * previous_smoothed_level) + (0.2 * raw_level)
-            previous_smoothed_level = smoothed_level
+                # Smooth the Peaks (Moving Average)
+                smoothed_level = (0.8 * previous_smoothed_level) + (0.2 * raw_level)
+                previous_smoothed_level = smoothed_level
 
-            # Create UDP-Paket
-            udp_packet = create_udp_packet(fft_data, raw_level, smoothed_level, peak_level, fft_magnitude_sum, fft_peak_frequency)
+                # Create UDP-Paket
+                udp_packet = create_udp_packet(fft_data, raw_level, smoothed_level, peak_level, fft_magnitude_sum, fft_peak_frequency)
 
-            # Send Package to WLED
-            udp_socket.sendto(udp_packet, (WLED_IP_ADDRESS, WLED_UDP_PORT))
-            # Send to multiple recievers
-            #for ip in WLED_IPS:
-                  #udp_socket.sendto(udp_packet, (ip, WLED_UDP_PORT))
+                # Send Package to WLED
+                udp_socket.sendto(udp_packet, (WLED_IP_ADDRESS, WLED_UDP_PORT))
+
+                # Send to multiple recievers
+                #for ip in WLED_IPS:
+                    #udp_socket.sendto(udp_packet, (ip, WLED_UDP_PORT))
 
     except KeyboardInterrupt:
         print("Audiostreaming closed.")
     finally:
         udp_socket.close()
 
-# start 
-stream_audio_to_wled()
+
+# start
+if args.source == "mic":
+    reader = make_mic_reader(args.alsa_device)
+    label = f"ALSA capture ({args.alsa_device})"
+else:
+    reader = make_stdin_reader()
+    label = "Pipe"
+
+try:
+    stream_audio_to_wled(reader, label)
+finally:
+    # clean up the ALSA PCM handle if we opened a mic stream
+    if args.source == "mic":
+        reader.pcm.close()

--- a/feed_my_wled.py
+++ b/feed_my_wled.py
@@ -4,12 +4,25 @@ import sys
 import configparser
 import socket
 import struct
+import argparse
 import numpy as np
 from collections import deque
 
+# Parse only the config file first
+config_parser = argparse.ArgumentParser(add_help=False)
+config_parser.add_argument(
+    "-c", "--config_file",
+    default="feed_my_wled.conf",
+    help="Configuration file"
+)
+
+config_args, remaining = config_parser.parse_known_args()
+
+
 # load preferences file
 config = configparser.ConfigParser()
-config.read("feed_my_wled.conf")
+#config.read("feed_my_wled.conf")
+config.read(config_args.config_file)
 
 #load preferences
 WLED_IP_ADDRESS = config.get("WLED", "WLED_IP_ADDRESS")

--- a/feed_my_wled.py
+++ b/feed_my_wled.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 import sys
 import configparser
 import socket

--- a/feed_my_wled.py
+++ b/feed_my_wled.py
@@ -13,6 +13,7 @@ config.read("feed_my_wled.conf")
 
 #load preferences
 WLED_IP_ADDRESS = config.get("WLED", "WLED_IP_ADDRESS")
+# WLED_IPS = config.get("WLED", "WLED_IPS")
 WLED_UDP_PORT = config.getint("WLED", "WLED_UDP_PORT")
 sample_rate = config.getint("Audio", "sample_rate")
 buffer_size = config.getint("Audio", "buffer_size")
@@ -109,7 +110,7 @@ def stream_audio_to_wled():
         ring_buffer.append(b"\x00" * chunk_size)
 
     try:
-        print(f"Start Pipe to WLED at ({WLED_IP_ADDRESS}:{WLED_UDP_PORT})...")
+        print(f"Starting Pipe to WLED at {WLED_IP_ADDRESS}:{WLED_UDP_PORT} ")
 
         # open stream from pipe
         while True:
@@ -122,7 +123,7 @@ def stream_audio_to_wled():
             combined_data = b"".join(ring_buffer)
 
             # Calc FFT and Peaks with buffersize
-            fft_result = calculate_fft(combined_data[:chunk_size])
+            fft_result = calculate_fft(combined_data[:chunk_size], sample_rate)
             if fft_result[0] is None:
                 print("Unvalid FFT-Datas, skip actual block.")
                 continue
@@ -139,6 +140,9 @@ def stream_audio_to_wled():
 
             # Send Package to WLED
             udp_socket.sendto(udp_packet, (WLED_IP_ADDRESS, WLED_UDP_PORT))
+            # Send to multiple recievers
+            #for ip in WLED_IPS:
+                  #udp_socket.sendto(udp_packet, (ip, WLED_UDP_PORT))
 
     except KeyboardInterrupt:
         print("Audiostreaming closed.")

--- a/systemd/feed-my-wled-ch1.service
+++ b/systemd/feed-my-wled-ch1.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Feed WLED Audio Channel 1
+After=sound.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Group=audio
+WorkingDirectory=/opt/feed_my_wled
+
+#ExecStart=/bin/bash -c 'arecord -D default:CARD=Device -c 1 -r 48000 -f S16_LE | ./feed_my_wled.py -c feed_my_wled-ch1.conf'
+ExecStart=/opt/feed_my_wled/feed_my_wled.py -D default:CARD=Device -s mic -c /opt/feed_my_wled/feed_my_wled-ch1.conf
+
+Restart=always
+RestartSec=2
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This version makes the python tool self-contained on the RPI 5 using Alsa audio and pyalsaaudio for the input. The default is to pull audio from STDIN still, but this allows you to configure the input device on the command like. This allows the python program to be run using system at boot. I have three services that start, and feed the audio to a Multicast address, on different ports for WLED.